### PR TITLE
Allow initial verification to trigger failures

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -335,7 +335,7 @@ export class EmailLinkStrategy<User> extends Strategy<
       email,
       form,
       magicLinkVerify: false,
-    }).catch(() => null)
+    })
 
     await this.sendEmail({
       emailAddress: email,


### PR DESCRIPTION
Thanks for this great library!

This is a tiny PR: The original code ignores exceptions when calling verify() only during the initial email step.  This change allows verify() to throw errors which bubble up to trigger the failureRedirect flow.

In my use case, I verify some of the form data before allowing the email to be sent.